### PR TITLE
Fix a timeout issue with broadcast vs incoming data

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ var Lirc = function (config) {
                 var lines = data.split('\n');
                 if (lines[lines.length - 1] === '') lines.pop();
 
-                if (data.match(/^[0-9a-f]{16} /)) {
+                if (data.match(/^[0-9a-f]{16} /) && !isIncoming) {
                     // Broadcast received
 
                     for (var i = 0; i < lines.length; i++) {


### PR DESCRIPTION
Fix a problem where a received line is perceived as a broadcast whereas we are receiving an answer. We check for "isIncoming" when branching into a broadcast.